### PR TITLE
Realurl upgrade to 2.0.x

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,7 +30,7 @@
 	url = git@bitbucket.org:pixelant/pxa_newsletter_subscription.git
 [submodule "typo3conf/ext/realurl"]
 	path = typo3conf/ext/realurl
-	url = https://git.typo3.org/TYPO3CMS/Extensions/realurl.git
+	url = git@github.com:dmitryd/typo3-realurl.git
 [submodule "typo3conf/ext/go_maps_ext"]
 	path = typo3conf/ext/go_maps_ext
 	url = git@github.com:mhirdes/go_maps_ext.git

--- a/typo3conf/LocalConfiguration.php
+++ b/typo3conf/LocalConfiguration.php
@@ -113,5 +113,6 @@ return [
         't3lib_cs_convMethod' => 'mbstring',
         't3lib_cs_utils' => 'mbstring',
         'textfile_ext' => 'txt,ts,typoscript,html,htm,css,tmpl,js,sql,xml,csv,xlf,less',
+        'trustedHostsPattern' => 'php56.t3kit.local.typo3.org',
     ],
 ];

--- a/typo3conf/PackageStates.php
+++ b/typo3conf/PackageStates.php
@@ -252,24 +252,6 @@ return [
             'packagePath' => 'typo3/sysext/viewpage/',
             'suggestions' => [],
         ],
-        'static_info_tables' => [
-            'composerName' => 'sjbr/static_info_tables',
-            'state' => 'active',
-            'packagePath' => 'typo3conf/ext/static_info_tables/',
-            'suggestions' => [],
-        ],
-        'yaml_parser' => [
-            'composerName' => 'typo3-ter/yaml-parser',
-            'state' => 'active',
-            'packagePath' => 'typo3conf/ext/yaml_parser/',
-            'suggestions' => [],
-        ],
-        'themes' => [
-            'composerName' => 'typo3-themes/themes',
-            'state' => 'active',
-            'packagePath' => 'typo3conf/ext/themes/',
-            'suggestions' => [],
-        ],
         'dyncss' => [
             'composerName' => 'dyncss',
             'state' => 'active',
@@ -280,6 +262,18 @@ return [
             'composerName' => 'dyncss_less',
             'state' => 'active',
             'packagePath' => 'typo3conf/ext/dyncss_less/',
+            'suggestions' => [],
+        ],
+        'static_info_tables' => [
+            'composerName' => 'sjbr/static_info_tables',
+            'state' => 'active',
+            'packagePath' => 'typo3conf/ext/static_info_tables/',
+            'suggestions' => [],
+        ],
+        'themes' => [
+            'composerName' => 'typo3-themes/themes',
+            'state' => 'active',
+            'packagePath' => 'typo3conf/ext/themes/',
             'suggestions' => [],
         ],
         'gridelements' => [
@@ -307,7 +301,7 @@ return [
             'suggestions' => [],
         ],
         'realurl' => [
-            'composerName' => 'realurl',
+            'composerName' => 'dmitryd/typo3-realurl',
             'state' => 'active',
             'packagePath' => 'typo3conf/ext/realurl/',
             'suggestions' => [
@@ -354,6 +348,12 @@ return [
             'composerName' => 'apache-solr-for-typo3/solr',
             'state' => 'active',
             'packagePath' => 'typo3conf/ext/solr/',
+            'suggestions' => [],
+        ],
+        'yaml_parser' => [
+            'composerName' => 'typo3-ter/yaml-parser',
+            'state' => 'active',
+            'packagePath' => 'typo3conf/ext/yaml_parser/',
             'suggestions' => [],
         ],
         'adodb' => [


### PR DESCRIPTION
This fixes langauge menu bug for news.

Switched to new repository for realurl and upgraded to 2.0.X. However a database upgrade is needed, since the realurl uses slightly different tables. Easiest way to do it for existing sites is to drop tx_realurl_pathcache and let install tool create tables again. (since it has changed its primary key). Will create a pull request for the t3kit/t3kit_db which respects these changes as well, so please approve it in the same time after testing.