### PR TITLE
[TASK] Update realurl_404_multilingual remote repo and to version 1.0.7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,7 +45,7 @@
 	url = git@github.com:pixelant/t3ext-seo_basics.git
 [submodule "typo3conf/ext/realurl_404_multilingual"]
 	path = typo3conf/ext/realurl_404_multilingual
-	url = git@github.com:pixelant/realurl_404_multilingual.git
+	url = git@github.com:svewap/realurl_404_multilingual.git
 [submodule "typo3conf/ext/theme_t3kit_bluemountain"]
 	path = typo3conf/ext/theme_t3kit_bluemountain
 	url = git@github.com:t3kit/theme_t3kit_bluemountain.git


### PR DESCRIPTION
We don't need any special repo anymore since code is updated and works in TYPO3 version 7.
Also changed to version 1.0.7 of extension realurl_404_multilingual.
