### PR TITLE
[TASK] Unify commit message documentation with TYPO3 coding standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,22 +102,18 @@ For example to pointing commit with bug report or feature request from Podio nee
 Please use semantic labels for your messages, but if commit message is not very important, you can skip labels. All commits with labels will be added in CHANGELOG file, that's why it is important to use predefined labels on your commits.
 
 * **[FEATURE]** - A new feature
-* **[FIX]** - A bug fix
-* **[REFACTOR]** - A code change that neither fixes a bug or adds a feature
-* **[PERF]** - A code change that improves performance.
-* **[CHORE]** - Changes to the build process (grunt) or auxiliary tools and libraries such as documentation generation and linters (jshint, jscs, etc.)
+* **[BUGFIX]** - A bug fix
+* **[CLEANUP]** - A code change that neither fixes a bug or adds a feature
 * **[DOC]** - Documentation only changes
-* **[STYLE]** - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
 * **[TEST]** - Adding missing tests
-* **[UPDATE]** - Updating git submodules, npm/bower dependencies
 * **[!!!]** - Breaking Changes
-
+* **[WIP]** - Work in progress tag, should not be present when creating pull requests
 **Important:** Commit label must be **only one**, except if it Breaking Changes, then we will need to add _"Breaking Changes"_ label `[!!!]` plus one more label.
 
 
 For example (Breaking Changes):
 ```
-[!!!][FIX] disable custom.js in t3kit
+[!!!][BUGFIX] disable custom.js in t3kit
 ```
 
 ### Message:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,11 +103,12 @@ Please use semantic labels for your messages, but if commit message is not very 
 
 * **[FEATURE]** - A new feature
 * **[BUGFIX]** - A bug fix
-* **[CLEANUP]** - A code change that neither fixes a bug or adds a feature
-* **[DOC]** - Documentation only changes
+* **[CLEANUP]** - A coding style fixes, compliance etc
+* **[TASK]** - Refactoring and similar, including performance
 * **[TEST]** - Adding missing tests
 * **[!!!]** - Breaking Changes
 * **[WIP]** - Work in progress tag, should not be present when creating pull requests
+* **[SECURITY]** - To mark important updates, when evaluating when we should update older sites
 **Important:** Commit label must be **only one**, except if it Breaking Changes, then we will need to add _"Breaking Changes"_ label `[!!!]` plus one more label.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,7 @@ Please use semantic labels for your messages, but if commit message is not very 
 * **[CLEANUP]** - A coding style fixes, compliance etc
 * **[TASK]** - Refactoring and similar, including performance
 * **[TEST]** - Adding missing tests
+* **[DOC]** - Documentation only changes
 * **[!!!]** - Breaking Changes
 * **[WIP]** - Work in progress tag, should not be present when creating pull requests
 * **[SECURITY]** - To mark important updates, when evaluating when we should update older sites


### PR DESCRIPTION
I did review the existing ones and we just had too many. Proposed change:
[FIX] -> [BUGFIX] - no problem there
[REFACTOR] -> [TASK] - also pretty straight forward
[STYLE] -> [CLEANUP] pretty straightforward too
[PERF] -> [FEATURE] or [TASK] - this would be never used, since you tune performance mostly by creating some new caching layer or by refactoring some old code, which in itself is different tag
[CHORE] -> [TASK] These are changes to the product we are providing, we should not treat them differently just because they are not seen in the final product by editors or visitors
[UPDATE] -> [TASK] or others, gets message mostly from other modules, which are being updated

I should get rid of [TEST] tag for complete unification, but since we are not having enough tests, I would like to track progress of those more easily by keeping this tag there,

added new one [WIP] so people would commit and push code to their branches daily. Please let me know if you disagree with any of these changes. I will ask everyone added here to review and comment on this before merging, so we can spread the word afterwards.

