### PR TITLE
[BUGFIX] Add missing typo3_console base commmand script

### DIFF
--- a/typo3cms
+++ b/typo3cms
@@ -1,0 +1,11 @@
+#!/usr/bin/env php
+<?php
+if (file_exists(__DIR__ . '/typo3cms.php')) {
+    require __DIR__ . '/typo3cms.php';
+} elseif (file_exists(__DIR__ . '/typo3conf/ext/typo3_console/Scripts/typo3cms.php')) {
+    // In non Composer mode we're copied into TYPO3 web root
+    putenv('TYPO3_PATH_WEB=' . __DIR__);
+    require __DIR__ . '/typo3conf/ext/typo3_console/Scripts/typo3cms.php';
+}
+echo 'Could not find console! Make sure typo3cms binary is up to date!' . PHP_EOL;
+exit(1);

--- a/typo3cms.bat
+++ b/typo3cms.bat
@@ -1,0 +1,8 @@
+@ECHO OFF
+
+REM Replace the following line with the path to your PHP executable if required
+REM This can include the php.ini to be used (for example "SET PHP=C:/php/php.exe -c C:/php/php.ini")
+
+SET PHP=php.exe
+
+%PHP% %~dp0typo3conf/ext/typo3_console/Scripts/typo3cms.php %*


### PR DESCRIPTION
@MattiasNilsson I added these two files into this repository because they are base script to run execute typo3 command with typo3_console without composer mode.