### PR TITLE
[!!!][TASK] Add Solr container to t3kit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ vendor
 typo3_src
 
 composer.lock
+
+# Solr
+solrdata/*
+# Keep the actual folder
+!solrdata/.gitkeep

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,19 @@ services:
       - "8888:80"
     depends_on:
       - db
+      - t3kit_solr
     volumes:
       - ./docker_conf:/docker_conf
       - ./vendor/t3kit/db:/t3kit_db
       - .:/var/www/html
     restart: always
     command: "sh /docker_conf/run.sh"
+
+  t3kit_solr:
+    container_name: t3kit_solr
+    image: typo3solr/ext-solr:6.0.0
+    ports:
+      - "8983:8983"
+    volumes:
+      - $PWD/solrdata:/opt/solr/server/solr/data/
+    restart: always


### PR DESCRIPTION
A new container (typo3solr/ext-solr:6.0.0) have been added to the
docker compose configuration.

Installation:

* Rebuild/Build all the containers with docker-compose