### PR TITLE
[!!!][TASK] Replace seo_basics with cs_seo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,6 @@
     "php": "^7.0",
     "typo3/cms": "8.5",
     "typo3-ter/realurl": "^2.1",
-    "b13/seo_basics": "0.9.6",
     "typo3-themes/themes": "dev-typo3_8_compatibility",
     "t3kit/t3kit-extension-tools": "dev-typo3_8.x_compatibility",
     "t3kit/theme-t3kit": "dev-master",
@@ -78,6 +77,7 @@
     "typo3-ter/dyncss": "0.8.0",
     "typo3-ter/dyncss-less": ">=0.7.8 <=0.7.99",
     "clickstorm/go_maps_ext": "2.2.0",
+    "clickstorm/cs_seo": "^2.0",
     "typo3-ter/news": "5.3.2",
     "typo3-ter/static-info-tables": "^6.4",
     "pixelant/pxa-cookie-bar": "1.0.4"


### PR DESCRIPTION
This commit adds a new SEO module for T3Kit cs_seo:

https://typo3.org/extensions/repository/view/cs_seo

Fixes: #118