### PR TITLE
[TASK] add route configuration for news extension

### DIFF
--- a/config/sites/t3kit/config.yaml
+++ b/config/sites/t3kit/config.yaml
@@ -50,3 +50,6 @@ routes:
     route: robots.txt
     type: staticText
     content: "User-agent: *\r\nDisallow: /typo3/\r\nDisallow: /typo3_src/\r\nAllow: /typo3/sysext/frontend/Resources/Public/*"
+
+imports:
+  - { resource: "typo3conf/sites/global/route-enhancers-news.yaml" }

--- a/web/typo3conf/sites/global/route-enhancers-news.yaml
+++ b/web/typo3conf/sites/global/route-enhancers-news.yaml
@@ -31,26 +31,9 @@ routeEnhancers:
           - locale: 'sv_SE.*'
             value: 'arkiv'
       year:
-        type: StaticValueMapper
-        map:
-          2005: 2005
-          2006: 2006
-          2007: 2007
-          2008: 2008
-          2009: 2009
-          2010: 2010
-          2011: 2011
-          2012: 2012
-          2013: 2013
-          2014: 2014
-          2015: 2015
-          2016: 2016
-          2017: 2017
-          2018: 2018
-          2019: 2019
-          2020: 2020
-          2021: 2021
-          2022: 2022
+        type: StaticRangeMapper
+        start: '2000'
+        end: '2050'
       month:
         type: StaticValueMapper
         map:

--- a/web/typo3conf/sites/global/route-enhancers-news.yaml
+++ b/web/typo3conf/sites/global/route-enhancers-news.yaml
@@ -1,5 +1,5 @@
 routeEnhancers:
-  NewsDetail:
+  NewsPlugin:
     type: Extbase
     limitToPages: [44]
     extension: News

--- a/web/typo3conf/sites/global/route-enhancers-news.yaml
+++ b/web/typo3conf/sites/global/route-enhancers-news.yaml
@@ -1,0 +1,127 @@
+routeEnhancers:
+  NewsDetail:
+    type: Extbase
+    limitToPages: [44]
+    extension: News
+    plugin: Pi1
+    routes:
+      - { routePath: '/{localized_page}/{page_number}', _controller: 'News::list', _arguments: {'page_number': '@widget_0/currentPage'} }
+      - { routePath: '/{localize_detail}/{news_title}', _controller: 'News::detail', _arguments: {'news_title': 'news'} }
+      - { routePath: '/{localize_archive}/{year}/{month}', _controller: 'News::list', _arguments: {'year': 'overwriteDemand/year', 'month': 'overwriteDemand/month'} }
+      - { routePath: '/{localize_category}/{category_title}', _controller: 'News::list', _arguments: {'category_title': 'overwriteDemand/categories'} }
+      - { routePath: '/{localize_tag}/{tag_title}', _controller: 'News::list', _arguments: {'tag_title': 'overwriteDemand/tags'} }
+
+    defaultController: 'News::list'
+    aspects:
+      localize_detail:
+        type: LocaleModifier
+        default: 'detail'
+        localeMap:
+          - locale: 'sv_SE.*'
+            value: 'detalj'
+      news_title:
+        type: PersistedAliasMapper
+        tableName: 'tx_news_domain_model_news'
+        routeFieldName: 'path_segment'
+        #routeValuePrefix: '/'
+      localize_archive:
+        type: LocaleModifier
+        default: 'archive'
+        localeMap:
+          - locale: 'sv_SE.*'
+            value: 'arkiv'
+      year:
+        type: StaticValueMapper
+        map:
+          2005: 2005
+          2006: 2006
+          2007: 2007
+          2008: 2008
+          2009: 2009
+          2010: 2010
+          2011: 2011
+          2012: 2012
+          2013: 2013
+          2014: 2014
+          2015: 2015
+          2016: 2016
+          2017: 2017
+          2018: 2018
+          2019: 2019
+          2020: 2020
+          2021: 2021
+          2022: 2022
+      month:
+        type: StaticValueMapper
+        map:
+          january: '01'
+          february: '02'
+          march: '03'
+          april: '04'
+          may: '05'
+          june: '06'
+          july: '07'
+          august: '08'
+          september: '09'
+          october: '10'
+          november: '11'
+          december: '12'
+        localeMap:
+          - locale: 'de_.*'
+            map:
+              januar: '01'
+              februar: '02'
+              maerz: '03'
+              april: '04'
+              mai: '05'
+              juni: '06'
+              juli: '07'
+              august: '08'
+              september: '09'
+              oktober: '10'
+              november: '11'
+              dezember: '12'
+          - locale: 'sv_SE.*'
+            map:
+              januari: '01'
+              februari: '02'
+              mars: '03'
+              april: '04'
+              maj: '05'
+              juni: '06'
+              juli: '07'
+              augusti: '08'
+              september: '09'
+              oktober: '10'
+              november: '11'
+              december: '12'
+      localize_category:
+        type: LocaleModifier
+        default: 'category'
+        localeMap:
+          - locale: 'sv_SE.*'
+            value: 'kategori'
+      category_title:
+        type: PersistedAliasMapper
+        tableName: 'sys_category'
+        routeFieldName: 'slug'
+      localize_tag:
+        type: LocaleModifier
+        default: 'tag'
+        localeMap:
+          - locale: 'sv_SE.*'
+            value: 'tagg'
+      tag_title:
+        type: PersistedAliasMapper
+        tableName: 'tx_news_domain_model_tag'
+        routeFieldName: 'slug'
+      localized_page:
+        type: LocaleModifier
+        default: 'page'
+        localeMap:
+          - locale: 'sv_SE.*'
+            value: 'sida'
+      page_number:
+        type: StaticRangeMapper
+        start: '1'
+        end: '100'


### PR DESCRIPTION
1. Route configuration for news, that allow to have everything(list,detail,date menu,tag,categories) on one list page. 