### PR TITLE
[TASK] use route instead of routeEnhancer for sitemap.xml so it isn't…

### DIFF
--- a/config/sites/t3kit/config.yaml
+++ b/config/sites/t3kit/config.yaml
@@ -50,12 +50,10 @@ routes:
     route: robots.txt
     type: staticText
     content: "User-agent: *\r\n\r\nDisallow: /typo3/\r\nDisallow: /typo3conf/\r\nAllow: /typo3conf/ext/\r\n\r\n# sitemap\r\nSitemap: https://BASE_DOMAIN/sitemap.xml"
-
-routeEnhancers:
-  PageTypeSuffix:
-    type: PageType
-    map:
-      sitemap.xml: 1533906435
+  -
+    route: sitemap.xml
+    type: uri
+    source: 't3://page?uid=1 - - - &type=1533906435'
 
 imports:
   - { resource: "typo3conf/sites/global/route-enhancers-news.yaml" }


### PR DESCRIPTION
… necessary to add all PageTypes to site configuration

Seems like TYPO3 ignores all pageTypes not configured in routeEnhancers  PageTypeSuffix