### PR TITLE
[TASK] stretched-link-wrp added on static elements that supports 'Enable whole area link'

### DIFF
--- a/Resources/Private/Templates/ContentElements/Static/BigIconTextLink.html
+++ b/Resources/Private/Templates/ContentElements/Static/BigIconTextLink.html
@@ -13,7 +13,8 @@
 
   <div class="ce-big-icon-text-link__wrp
     {f:if(condition: flexform.internal_margins, then: ' internal-margins')}
-    {f:if(condition: flexform.inverted_color, then: ' inverted-color')}">
+    {f:if(condition: flexform.inverted_color, then: ' inverted-color')}
+    {f:if(condition: flexform.stretched_link, then: ' stretched-link-wrp')}">
 
     <div class="ce-big-icon-text-link">
 

--- a/Resources/Private/Templates/ContentElements/Static/IconTextLink.html
+++ b/Resources/Private/Templates/ContentElements/Static/IconTextLink.html
@@ -13,7 +13,8 @@
 
   <div class="ce-icon-text-link__wrp
     {f:if(condition: flexform.internal_margins, then: ' internal-margins')}
-    {f:if(condition: flexform.inverted_color, then: ' inverted-color')}">
+    {f:if(condition: flexform.inverted_color, then: ' inverted-color')}
+    {f:if(condition: flexform.stretched_link, then: ' stretched-link-wrp')}">
 
     <div class="ce-icon-text-link">
 

--- a/Resources/Private/Templates/ContentElements/Static/ImageTextLink.html
+++ b/Resources/Private/Templates/ContentElements/Static/ImageTextLink.html
@@ -17,7 +17,8 @@
 
   <div class="ce-img-text-link__wrp
     {f:if(condition: flexform.internal_margins, then: ' internal-margins')}
-    {f:if(condition: flexform.inverted_color, then: ' inverted-color')}">
+    {f:if(condition: flexform.inverted_color, then: ' inverted-color')}
+    {f:if(condition: flexform.stretched_link, then: ' stretched-link-wrp')}">
 
     <div class="ce-img-text-link">
 


### PR DESCRIPTION


# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [x] Contributing to t3kit: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md>
- [x] Coding Rules: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [x] Commit message conventions: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [ ] [BUGFIX] - A bug fix
- [x] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Issue references

Issue Number: #...

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->

Adds a class to all static elements that supports 'Enable whole are link'. This makes it possible to style a hover or other effect on the elements when this checkbox is checked in the flexform.