### PR TITLE
[BUGFIX] don't install husky on Composer non-git install

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "authors": "t3kit Community",
   "repository": "t3kit/t3kit",
   "scripts": {
-    "postinstall": "husky install",
+    "postinstall": "node -e \"if(require('fs').existsSync('.git')){process.exit(1)}\" || husky install",
     "lint-css": "stylelint 'theme/src/css/**/*.css'",
     "lint-scss": "stylelint 'theme/src/scss/**/*.scss'",
     "lint-js": "standard -v 'theme/src/js/**/*.js' | snazzy",


### PR DESCRIPTION
# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [x] Contributing to t3kit: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md>
- [x] Coding Rules: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [x] Commit message conventions: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description

Adds a cross-platform condition in the package.json file that disables husky if it isn't needed. When installing the extension through Composer and it is downloaded as archive (rather than using a git clone), it will be downloaded without the .git repository. This will make husky complain because it explicitly requires to be run in a folder containing a folder named ".git". That makes sense, because husky is supposed to add git hooks. If there is no git, you don't need husky either. Arguably, husky should deal with these kind of edge cases, but making it aware of Composer is maybe a bit much to ask.
