### PR TITLE
[!!!][BUGFIX] Change sys_file_reference.picture_width to tinyint

### DIFF
--- a/Classes/Updates/AbstractUpgradeWizard.php
+++ b/Classes/Updates/AbstractUpgradeWizard.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace T3k\t3kit\Updates;
+
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+abstract class AbstractUpgradeWizard implements UpgradeWizardInterface
+{
+    public const TABLE_NAME = '';
+
+    public const IDENTIFIER = 't3kit_';
+
+    public const TITLE = '';
+
+    public const DESCRIPTION = '';
+
+    /**
+     * @inheritDoc
+     */
+    final public function getIdentifier(): string
+    {
+        return static::IDENTIFIER;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTitle(): string
+    {
+        return static::TITLE;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDescription(): string
+    {
+        return static::DESCRIPTION;
+    }
+
+
+    /**
+     * Returns the QueryBuilder with all restrictions removed.
+     *
+     * @return QueryBuilder
+     */
+    protected function getQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable(static::TABLE_NAME)
+            ->createQueryBuilder();
+
+        $queryBuilder->getRestrictions()->removeAll();
+
+        return $queryBuilder;
+    }
+}

--- a/Classes/Updates/AbstractUpgradeWizard.php
+++ b/Classes/Updates/AbstractUpgradeWizard.php
@@ -2,9 +2,7 @@
 
 declare(strict_types=1);
 
-
 namespace T3k\t3kit\Updates;
-
 
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;

--- a/Classes/Updates/SysFileReferencePrepareStringToIntegerUpgradeWizard.php
+++ b/Classes/Updates/SysFileReferencePrepareStringToIntegerUpgradeWizard.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace T3k\t3kit\Updates;
+
+class SysFileReferencePrepareStringToIntegerUpgradeWizard extends AbstractUpgradeWizard
+{
+    public const TABLE_NAME = 'sys_file_reference';
+
+    public const IDENTIFIER = 't3kit_sysFileReferencePrepareStringToInteger';
+
+    public const TITLE = 'Remove empty picture_width strings';
+
+    public const DESCRIPTION = 'Changes the value of sys_file_reference.picture_width from "" to "100" '
+        . 'to prepare the field for conversion to integer.';
+
+    /**
+     * @inheritDoc
+     */
+    public function executeUpdate(): bool
+    {
+        $queryBuilder = $this->getQueryBuilder();
+
+        return (bool)$queryBuilder
+            ->update(self::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->eq('picture_width', $queryBuilder->createNamedParameter(''))
+            )
+            ->set('picture_width', '100', false, \PDO::PARAM_STR)
+            ->execute();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateNecessary(): bool
+    {
+        $queryBuilder = $this->getQueryBuilder();
+
+        return (bool)$queryBuilder
+            ->count('uid')
+            ->from(self::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->eq('picture_width', $queryBuilder->createNamedParameter(''))
+            )
+            ->execute()
+            ->fetchOne();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPrerequisites(): array
+    {
+        return [];
+    }
+}

--- a/Classes/Updates/SysFileReferencePrepareStringToIntegerUpgradeWizard.php
+++ b/Classes/Updates/SysFileReferencePrepareStringToIntegerUpgradeWizard.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 namespace T3k\t3kit\Updates;
 
 class SysFileReferencePrepareStringToIntegerUpgradeWizard extends AbstractUpgradeWizard

--- a/Configuration/TCA/Overrides/60_sys_file_reference.php
+++ b/Configuration/TCA/Overrides/60_sys_file_reference.php
@@ -66,42 +66,42 @@ $GLOBALS['TCA']['sys_file_reference']['columns']['link']  = array_replace_recurs
             'items' => [
                 [
                     'LLL:EXT:t3kit/Resources/Private/Language/ContentElements/locallang.xlf:picture_width.100',
-                    '100'
+                    100
                 ],
                 [
                     'LLL:EXT:t3kit/Resources/Private/Language/ContentElements/locallang.xlf:picture_width.90',
-                    '90'
+                    90
                 ],
                 [
                     'LLL:EXT:t3kit/Resources/Private/Language/ContentElements/locallang.xlf:picture_width.80',
-                    '80'
+                    80
                 ],
                 [
                     'LLL:EXT:t3kit/Resources/Private/Language/ContentElements/locallang.xlf:picture_width.70',
-                    '70'
+                    70
                 ],
                 [
                     'LLL:EXT:t3kit/Resources/Private/Language/ContentElements/locallang.xlf:picture_width.60',
-                    '60'
+                    60
                 ],
                 [
                     'LLL:EXT:t3kit/Resources/Private/Language/ContentElements/locallang.xlf:picture_width.50',
-                    '50'
+                    50
                 ],
                 [
                     'LLL:EXT:t3kit/Resources/Private/Language/ContentElements/locallang.xlf:picture_width.40',
-                    '40'
+                    40
                 ],
                 [
                     'LLL:EXT:t3kit/Resources/Private/Language/ContentElements/locallang.xlf:picture_width.30',
-                    '30'
+                    30
                 ],
                 [
                     'LLL:EXT:t3kit/Resources/Private/Language/ContentElements/locallang.xlf:picture_width.20',
-                    '20'
+                    20
                 ]
             ],
-            'default' => '100',
+            'default' => 100,
         ]
     ],
 ]);

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -147,3 +147,8 @@ if (empty($GLOBALS['TYPO3_CONF_VARS']['RTE']['Presets']['t3kit_default'])) {
 
 // Register report module additions
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['reports']['tx_reports']['status']['providers']['security'][] = \T3k\t3kit\Report\T3kitSecurityStatus::class;
+
+// Register upgrade wizards
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][
+    \T3k\t3kit\Updates\SysFileReferencePrepareStringToIntegerUpgradeWizard::IDENTIFIER
+] = \T3k\t3kit\Updates\SysFileReferencePrepareStringToIntegerUpgradeWizard::class;

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -125,7 +125,7 @@ CREATE TABLE tx_t3kit_accordion_item (
 #
 CREATE TABLE sys_file_reference (
 	description_position varchar(60) DEFAULT '' NOT NULL,
-	picture_width varchar(60) DEFAULT '' NOT NULL,
+	picture_width tinyint(3) unsigned DEFAULT '100' NOT NULL,
 	picture_border_radius varchar(60) DEFAULT '' NOT NULL,
 	aspect_ratio varchar(60) DEFAULT '' NOT NULL,
 	svg_width mediumint(8) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Fixes #297

# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [ ] Contributing to t3kit: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md>
- [ ] Coding Rules: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [ ] Commit message conventions: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Issue references

Issue Number: #297

## Description

The field was varchar, which led to parsing issues in Fluid calculations if the default value (empty string) was used. The field will now always be a number and the default value is 100, the default value defined in TCA.
