### PR TITLE
[BUGFIX] Allow empty menus in footer

### DIFF
--- a/Configuration/TypoScript/ContentElement/Groups/Special/SiteFooter.typoscript
+++ b/Configuration/TypoScript/ContentElement/Groups/Special/SiteFooter.typoscript
@@ -26,6 +26,7 @@ tt_content.siteFooter {
 
     50 = TYPO3\CMS\Frontend\DataProcessing\MenuProcessor
     50 {
+      if.isTrue.field = page_links_1
       special = list
       special.value.field = page_links_1
       includeNotInMenu = 1
@@ -41,6 +42,7 @@ tt_content.siteFooter {
 
     60 = TYPO3\CMS\Frontend\DataProcessing\MenuProcessor
     60 {
+      if.isTrue.field = page_links_2
       special = list
       special.value.field = page_links_2
       includeNotInMenu = 1
@@ -56,6 +58,7 @@ tt_content.siteFooter {
 
     70 = TYPO3\CMS\Frontend\DataProcessing\MenuProcessor
     70 {
+      if.isTrue.field = page_links_2
       special = list
       special.value.field = page_links_3
       includeNotInMenu = 1
@@ -71,6 +74,7 @@ tt_content.siteFooter {
 
     80 = TYPO3\CMS\Frontend\DataProcessing\MenuProcessor
     80 {
+      if.isTrue.field = pages
       special = list
       special.value.field = pages
       includeNotInMenu = 1
@@ -79,5 +83,3 @@ tt_content.siteFooter {
 
   }
 }
-
-


### PR DESCRIPTION
# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [x] Contributing to t3kit: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md>
- [x] Coding Rules: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [x] Commit message conventions: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->



## Description

If no items were selected for the link columns and the footer bootom links in the footer content element, they would all display a link to the home page. This bugfix adds a condition that prevents the menu from rendering if there are no items selected.

