### PR TITLE
[FEATURE] Don't render unused sections in StartPage.html

### DIFF
--- a/Configuration/TypoScript/ContentElement/Lib/ContentRenderCount.typoscript
+++ b/Configuration/TypoScript/ContentElement/Lib/ContentRenderCount.typoscript
@@ -1,0 +1,14 @@
+lib.contentRenderCount < lib.contentRender
+lib.contentRenderCount {
+  30 {
+    select {
+      orderBy >
+      where = {#colPos} IN ({field:colPos})
+      max = 1
+    }
+
+    renderObj >
+    renderObj = TEXT
+    renderObj.value = 1
+  }
+}

--- a/Resources/Private/Templates/Page/StartPage.html
+++ b/Resources/Private/Templates/Page/StartPage.html
@@ -40,293 +40,333 @@
   <main id="main" class="start-page">
 
     <section class="start-page__top-content">
-      <div class="start-page__top-content-container pb-5">
-        <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:50}" />
-      </div>
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'50'})}">
+        <div class="start-page__top-content-container pb-5">
+          <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:50}" />
+        </div>
+      </f:if>
     </section>
 
     <section class="start-page__before-content">
-      <div class="start-page__before-content-container">
-        <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:60}" />
-      </div>
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'60'})}">
+        <div class="start-page__before-content-container">
+          <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:60}" />
+        </div>
+      </f:if>
     </section>
 
     <section class="start-page__content">
 
-      <div class="container-wrp pt-2 pt-lg-4 ">
-        <div class="container">
-          <div class="row">
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3301}" />
-            </div>
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'3301,3302,3303'})}">
+        <div class="container-wrp pt-2 pt-lg-4 ">
+          <div class="container">
+            <div class="row">
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3301}" />
+              </div>
 
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3302}" />
-            </div>
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3302}" />
+              </div>
 
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3303}" />
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3303}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
 
-      <div class="container-wrp pt-lg-5 pb-5">
-        <div class="container">
-          <div class="row">
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3307}" />
-            </div>
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'3307,3308,3309'})}">
+        <div class="container-wrp pt-lg-5 pb-5">
+          <div class="container">
+            <div class="row">
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3307}" />
+              </div>
 
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3308}" />
-            </div>
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3308}" />
+              </div>
 
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3309}" />
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3309}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
 
-      <div class="container-wrp inverted-bg-color pt-5 pb-5 pt-lg-7 pb-lg-7">
-        <div class="container overflow-hidden">
-          <div class="row g-5 justify-content-around">
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3313}" />
-            </div>
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'3313,3314,3315'})}">
+        <div class="container-wrp inverted-bg-color pt-5 pb-5 pt-lg-7 pb-lg-7">
+          <div class="container overflow-hidden">
+            <div class="row g-5 justify-content-around">
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3313}" />
+              </div>
 
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3314}" />
-            </div>
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3314}" />
+              </div>
 
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3315}" />
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3315}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
 
-      <div class="container-wrp pt-5 pt-lg-0">
-        <div class="container">
-          <div class="row g-0 ">
-            <div class="col-lg-6 align-self-center figure-lg-margin-0">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5003}" />
-            </div>
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'5003,5004'})}">
+        <div class="container-wrp pt-5 pt-lg-0">
+          <div class="container">
+            <div class="row g-0 ">
+              <div class="col-lg-6 align-self-center figure-lg-margin-0">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5003}" />
+              </div>
 
-            <div class="col-lg-5 col-xl-4 offset-lg-1 align-self-center pb-5 pb-lg-0 ">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5004}" />
+              <div class="col-lg-5 col-xl-4 offset-lg-1 align-self-center pb-5 pb-lg-0 ">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5004}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
 
-      <div class="container-wrp pt-8 pb-8 inverted-bg-color">
-        <div class="container">
-          <div class="row">
-            <div class="offset-lg-1 col-lg-10">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:8302}" />
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'8302'})}">
+        <div class="container-wrp pt-8 pb-8 inverted-bg-color">
+          <div class="container">
+            <div class="row">
+              <div class="offset-lg-1 col-lg-10">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:8302}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
 
-      <div class="container-wrp pb-5 pt-5 pt-lg-0">
-        <div class="container">
-          <div class="row g-0 justify-content-between">
-            <div class="col-lg-5 align-self-center">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5007}" />
-            </div>
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'5007,5008,5009'})}">
+        <div class="container-wrp pb-5 pt-5 pt-lg-0">
+          <div class="container">
+            <div class="row g-0 justify-content-between">
+              <div class="col-lg-5 align-self-center">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5007}" />
+              </div>
 
-            <div class="col-lg-6  align-self-center figure-lg-margin-0">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5008}" />
+              <div class="col-lg-6  align-self-center figure-lg-margin-0">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5008}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
 
-      <div class="container-wrp pt-lg-8 ">
-        <div class="container">
-          <div class="row justify-content-center">
-            <div class="col-lg-9">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:8305}" />
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'8305'})}">
+        <div class="container-wrp pt-lg-8 ">
+          <div class="container">
+            <div class="row justify-content-center">
+              <div class="col-lg-9">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:8305}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
 
-      <div class="container-wrp pt-3 pb-5">
-        <div class="container">
-          <div class="row justify-content-center ">
-            <div class="col-lg-3 pb-5 pb-lg-0">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3319}" />
-            </div>
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'3319,3320,3321'})}">
+        <div class="container-wrp pt-3 pb-5">
+          <div class="container">
+            <div class="row justify-content-center ">
+              <div class="col-lg-3 pb-5 pb-lg-0">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3319}" />
+              </div>
 
-            <div class="col-lg-3 pb-5 pb-lg-0">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3320}" />
-            </div>
+              <div class="col-lg-3 pb-5 pb-lg-0">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3320}" />
+              </div>
 
-            <div class="col-lg-3 pb-5 pb-lg-0">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3321}" />
+              <div class="col-lg-3 pb-5 pb-lg-0">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3321}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
 
-      <div class="container-wrp gray-90-bg-color pt-5 pb-5">
-        <div class="container overflow-hidden">
-          <div class="row g-5">
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3325}" />
-            </div>
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'3325,3326,3327'})}">
+        <div class="container-wrp gray-90-bg-color pt-5 pb-5">
+          <div class="container overflow-hidden">
+            <div class="row g-5">
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3325}" />
+              </div>
 
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3326}" />
-            </div>
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3326}" />
+              </div>
 
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3327}" />
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3327}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
 
-      <div class="container-wrp pb-5 pb-lg-0 ">
-        <div class="container">
-          <div class="row g-0">
-            <div class="col-lg-6 align-self-center figure-lg-margin-0">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5011}" />
-            </div>
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'5011,5012'})}">
+        <div class="container-wrp pb-5 pb-lg-0 ">
+          <div class="container">
+            <div class="row g-0">
+              <div class="col-lg-6 align-self-center figure-lg-margin-0">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5011}" />
+              </div>
 
-            <div class="col-lg-5 col-xl-4 offset-lg-1 align-self-center">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5012}" />
+              <div class="col-lg-5 col-xl-4 offset-lg-1 align-self-center">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5012}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
 
-      <div class="container-wrp">
-        <div class="container">
-          <div class="row g-0">
-            <div class="col-lg-5 align-self-center">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5015}" />
-            </div>
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'5015,5016'})}">
+        <div class="container-wrp">
+          <div class="container">
+            <div class="row g-0">
+              <div class="col-lg-5 align-self-center">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5015}" />
+              </div>
 
-            <div class="col-lg-6 offset-lg-1 align-self-center figure-lg-margin-0">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5016}" />
+              <div class="col-lg-6 offset-lg-1 align-self-center figure-lg-margin-0">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:5016}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
 
-      <div class="container-wrp inverted-bg-color pt-5 pb-5">
-        <div class="container">
-          <div class="row g-xl-5 justify-content-center">
-            <div class="col-lg-3">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3331}" />
-            </div>
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'3331,3332,3333'})}">
+        <div class="container-wrp inverted-bg-color pt-5 pb-5">
+          <div class="container">
+            <div class="row g-xl-5 justify-content-center">
+              <div class="col-lg-3">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3331}" />
+              </div>
 
-            <div class="col-lg-3">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3332}" />
-            </div>
+              <div class="col-lg-3">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3332}" />
+              </div>
 
-            <div class="col-lg-3">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3333}" />
+              <div class="col-lg-3">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3333}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
 
-      <div class="container-wrp ">
-        <div class="container">
-          <div class="row g-0 ">
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3337}" />
-            </div>
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3338}" />
-            </div>
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'3337,3338,3339,3343,3344,3345'})}">
+        <div class="container-wrp ">
+          <div class="container">
+            <div class="row g-0 ">
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3337}" />
+              </div>
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3338}" />
+              </div>
 
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3339}" />
-            </div>
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3343}" />
-            </div>
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3339}" />
+              </div>
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3343}" />
+              </div>
 
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3344}" />
-            </div>
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3344}" />
+              </div>
 
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3345}" />
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3345}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
 
-      <div class="container-wrp pt-5 pb-5 pt-lg-6 pb-lg-6">
-        <div class="container">
-          <div class="row">
-            <div class="col-lg">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:1008}" />
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'1008'})}">
+        <div class="container-wrp pt-5 pb-5 pt-lg-6 pb-lg-6">
+          <div class="container">
+            <div class="row">
+              <div class="col-lg">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:1008}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
 
-      <div class="container-wrp ">
-        <div class="container overflow-hidden">
-          <div class="row g-5 justify-content-around">
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3349}" />
-            </div>
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'3349,3350,3351'})}">
+        <div class="container-wrp ">
+          <div class="container overflow-hidden">
+            <div class="row g-5 justify-content-around">
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3349}" />
+              </div>
 
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3350}" />
-            </div>
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3350}" />
+              </div>
 
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3351}" />
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="container-wrp pt-5 pb-5 pt-lg-6 pb-lg-6">
-        <div class="container">
-          <div class="row">
-            <div class="col-lg">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:1012}" />
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3351}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
 
-      <div class="container-wrp pb-5 pb-lg-7">
-        <div class="container overflow-hidden">
-          <div class="row g-5 justify-content-around">
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3355}" />
-            </div>
-
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3356}" />
-            </div>
-
-            <div class="col-lg-4">
-              <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3357}" />
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'1012'})}">
+        <div class="container-wrp pt-5 pb-5 pt-lg-6 pb-lg-6">
+          <div class="container">
+            <div class="row">
+              <div class="col-lg">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:1012}" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </f:if>
+
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'3355,3356,3357'})}">
+        <div class="container-wrp pb-5 pb-lg-7">
+          <div class="container overflow-hidden">
+            <div class="row g-5 justify-content-around">
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3355}" />
+              </div>
+
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3356}" />
+              </div>
+
+              <div class="col-lg-4">
+                <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:3357}" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </f:if>
 
     </section>
 
     <section class="start-page__after-content">
-      <div class="start-page__after-content-container">
-        <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:90}" />
-      </div>
+      <f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'90'})}">
+        <div class="start-page__after-content-container">
+          <f:cObject typoscriptObjectPath="lib.contentRender" data="{colPos:90}" />
+        </div>
+      </f:if>
     </section>
 
   </main>


### PR DESCRIPTION
# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [x] Contributing to t3kit: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md>
- [x] Coding Rules: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [x] Commit message conventions: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [x] [FEATURE] - A new feature
- [ ] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description

Introduces TypoScript `lib.contentRederCount`. This is used in a condition to test for the existence of content elements with colPos in the `colPos` argument. Compared the `lib.contentRender`, `colPos` is a commaseparated list of colPos values.

`<f:if condition="{f:cObject(typoscriptObjectPath:'lib.contentRenderCount', data:{colPos:'3301,3302,3303'})}">Only rendered if there are content elements in colPos 3301,3302,3303 on the page.</f:if>`

